### PR TITLE
Fix SyntaxError in f-string on line 266 of TPTV/init.py

### DIFF
--- a/unshackle/services/TPTV/__init__.py
+++ b/unshackle/services/TPTV/__init__.py
@@ -263,7 +263,7 @@ class TPTV(Service):
 
 
     def get_tracks(self, title: Union[Movie, Episode]) -> Tracks:
-        playlist = f"https://edge.api.brightcove.com/playback/v1/accounts/6272132012001/videos/{title.data.get("id")}"
+        playlist = f"https://edge.api.brightcove.com/playback/v1/accounts/6272132012001/videos/{title.data.get('id')}"
 
         headers = {
             'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0',


### PR DESCRIPTION
Replace double quotes with single quotes in title.data.get('id') to fix the SyntaxError: unmatched '(' that was preventing execution.